### PR TITLE
fix: add permissions to GitHub workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ on:
     - main
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code


### PR DESCRIPTION
Adding explicit permissions to the workflow to resolve this security issue https://github.com/sageailabs/sageai-examples/security/code-scanning/1